### PR TITLE
More arguments passed by druid.query.dimensions

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -100,8 +100,8 @@ druid.query.dataSources <- function(url = druid.url()) {
 #' @param dataSource name of the data source to query
 #' @return a character vector with the list of dimensions
 #' @export
-druid.query.dimensions <- function(url = druid.url(), dataSource, interval=NULL) {
-  query(NULL, paste(url, "datasources/", dataSource, sep=""), query = list(interval = toISO(interval)))$dimensions
+druid.query.dimensions <- function(url = druid.url(), dataSource, interval=NULL, ...) {
+  query(NULL, paste(url, "datasources/", dataSource, sep=""), query = list(interval = toISO(interval)), ...)$dimensions
 }
 
 #' Query data source metrics


### PR DESCRIPTION
Why there is no possibility to pass more arguments in druid.query.dimensions since it uses `query` that can take `...` ?
